### PR TITLE
bolus: force explicit selection of stroke size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	udevadm control --reload-rules
 
 docs:
-	(cd docs; make)
+	(cd doc; make)
 travis: test
 	# do the travis dance
 

--- a/bin/mm-bolus.py
+++ b/bin/mm-bolus.py
@@ -13,9 +13,17 @@ class BolusApp (cli.CommandApp):
   """
   def customize_parser (self, parser):
 
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--515',
+                        dest='strokes_per_unit', action='store_const',
+                        const=10
+                      )
+    group.add_argument('--strokes',
+                        dest='strokes_per_unit',
+                        type=int
+                      )
     parser.add_argument('--units',
-                        dest='strokes',
-                        type=fmt_params,
+                        type=float,
                         help="Amount of insulin to bolus. [default: %(default)s)]"
                         )
 
@@ -26,14 +34,14 @@ class BolusApp (cli.CommandApp):
 
   def bolus (self, args):
     query = commands.Bolus
-    kwds = dict(params=[args.strokes])
+    kwds = dict(params=[fmt_params(args)])
 
     resp = self.exec_request(self.pump, query, args=kwds,
                  dryrun=args.dryrun, render_hexdump=False)
     return resp
 
-def fmt_params (units):
-  return int(float(units) * 10)
+def fmt_params (args):
+  return int(float(args.units) * args.strokes_per_unit)
 
 if __name__ == '__main__':
   app = BolusApp( )


### PR DESCRIPTION
Make the bolus tool safer; the stroke sizes for pumps vary widely by model.
This script has only been tested on 515.

This change forces the user to explicitly declare either the pump
model or the stroke size to use.  This should allow easily re-using
the tool to discover stroke sizes fairly easily, in order to add the
pump specific option.

The tool will error out and refuse to do anything if the
strokes_per_unit has not been explicitly indicated, either through
specifying the pump model or the strokes option.
