### PR TITLE
perhaps related to model differences

### DIFF
--- a/decocare/history.py
+++ b/decocare/history.py
@@ -235,6 +235,12 @@ _confirmed.append(IanA8)
 class BasalProfileStart(KnownRecord):
   opcode = 0x7b
   body_length = 3
+  def __init__(self, head, larger=False):
+    super(type(self), self).__init__(head, larger)
+    if larger:
+      # body_length = 1
+      pass
+      # self.body_length = 48
   def decode (self):
     self.parse_time( )
     if (len(self.body) % 3 == 0):
@@ -412,8 +418,6 @@ class HistoryPage (PagedData):
     # XXX: under some circumstances, zero is the correct value and
     # eat_nulls actually eats valid data.  This ugly hack restores two
     # nulls back ot the end.
-    self.data.append(0x00)
-    self.data.append(0x00)
     self.data.append(0x00)
     self.data.append(0x00)
     self.data.append(0x00)

--- a/decocare/stick.py
+++ b/decocare/stick.py
@@ -577,7 +577,7 @@ class Stick(object):
     packet = self.process( )
     return packet
 
-  def send_force_read(self, retries=5, timeout=1):
+  def send_force_read(self, retries=2, timeout=1):
     """
     Pretty simple, try really hard to ensure that we've sent our bytes, and we
     get a response.
@@ -741,7 +741,7 @@ class Stick(object):
         log.warn("%s:BAD AILING" % (stats.format(self, i, size,
                                         len(results), len(data))))
         ailing = ailing + 1
-        if ailing > 5:
+        if ailing > 2:
           break
         continue
           # break

--- a/list_cgm.py
+++ b/list_cgm.py
@@ -104,6 +104,7 @@ class PagedData (object):
       0x02: dict(name='SensorWeakSignal',packet_size=0,date_type='prevTimestamp',op='0x02'),
       0x03: dict(name='SensorCal',packet_size=1,date_type='prevTimestamp',op='0x03'),
       0x08: dict(name='SensorTimestamp',packet_size=4,date_type='minSpecific',op='0x08'),
+      0x0a: dict(name='BatteryChange',packet_size=4,date_type='minSpecific',op='0x0a'),
       0x0b: dict(name='SensorStatus',packet_size=4,date_type='minSpecific',op='0x0b'),
       0x0c: dict(name='DateTimeChange',packet_size=14,date_type='secSpecific',op='0x0c'),
       0x0d: dict(name='SensorSync',packet_size=4,date_type='minSpecific',op='0x0d'),
@@ -187,13 +188,11 @@ class PagedData (object):
         records.append(record)
         prefix_records = []
 
-      elif record['name'] == 'SensorStatus' or record['name'] == 'DateTimeChange' \
-        or record['name'] == 'SensorSync' or record['name'] == '10-Something' \
-        or record['name'] == 'CalBGForGH' :
+
+      elif record['name'] in ['SensorStatus', 'DateTimeChange', 'SensorSync', '10-Something', 'CalBGForGH', 'BatteryChange' ]:
         # independent record => parse and add to records list
         record.update(raw=self.byte_to_str(raw_packet))
-        if record['name'] == 'SensorStatus' or record['name'] == 'SensorSync'\
-        or record['name'] == 'CalBGForGH' :
+        if record['name'] in ['SensorStatus', 'SensorSync', 'CalBGForGH', 'BatteryChange']:
           date, body = raw_packet[:4], raw_packet[4:]
           date.reverse()
           date = parse_date(date)


### PR DESCRIPTION
Really need to hone in on exact differences between models, which would help with #71 .

In meantime, I simply switch between `--larger` and "normal" which produces quirky results sometimes.

This hack attempts to restore nulls that were in the original input data, but got stripped out.