### PR TITLE
Wip/check responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	udevadm control --reload-rules
 
 ci-install:
-	sudo python setup.py develop
+	python setup.py develop
 
 docs:
 	(cd doc; make)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ install:
 ci-install:
 	python setup.py develop
 
+ci-test: ci-install test
+	# do the travis dance
+
 docs:
 	(cd doc; make)
 travis: test

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,3 @@
-dependencies:
+test:
   override:
-    - sudo python setup.py install
-
+    - make ci-test

--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -1093,9 +1093,17 @@ class ReadProfile_STD512 (PumpCommand):
     for profile in data:
       start = str(lib.basal_time(profile['minutes']/30))
       if 'rate' in profile and profile['i'] == i and start == profile['start']:
+        if i == 0:
+          if profile['minutes'] != 0:
+            template = "{name} first scheduled item should be 00:00:00."
+            msg = template.format(name=self.__class__.__name__)
+            msg = "%s\n%s" % (msg, profile)
+            raise BadResponse(msg)
         if last and profile['minutes'] <= last['minutes']:
-          template = "{name} next scheduled item occurs before previous %s" % profile
-          raise BadResponse(template.format(name=self.__class__.__name__))
+          template = "{name} next scheduled item occurs before previous"
+          msg = template.format(name=self.__class__.__name__)
+          msg = "%s\n%s" % (msg, profile)
+          raise BadResponse(msg)
       else:
         bad_profile = """Current profile: %s""" % (profile)
         template = """{bad_profile} Found in response to {name}

--- a/decocare/models/__init__.py
+++ b/decocare/models/__init__.py
@@ -13,6 +13,9 @@ class Task (object):
       return self
     else:
       return types.MethodType(self, obj)
+  def validate (self):
+    data = self.response.getData( )
+    self.response.check_output(data)
   @staticmethod
   def func (self, response):
     return response.getData( )
@@ -20,6 +23,7 @@ class Task (object):
     # print "__calll__", inst, self.func
     # self.func( )
     self.response = inst.session.query(self.msg, **kwds)
+    self.validate( )
     return types.MethodType(self.func, inst)(self.response)
     # return self.response.getData( )
 


### PR DESCRIPTION
Help check outputs.
This should help guard against mismatched responses when multiple clients are interacting with the same pump at the same time.