### PR TITLE
fix carb ratio

### DIFF
--- a/decocare/records/bolus.py
+++ b/decocare/records/bolus.py
@@ -122,7 +122,7 @@ class BolusWizard(KnownRecord):
       # https://github.com/ps2/minimed_rf/blob/master/lib/minimed_rf/log_entries/bolus_wizard.rb#L102
       sensitivity = int(self.body[4])
       wizard = { 'bg': bg, 'carb_input': carb_input,
-                 'carb_ratio': int(self.body[1])/ 10.0,
+                 'carb_ratio': carb_ratio,
                  'sensitivity': sensitivity,
                  'bg_target_low': int(self.body[5]),
                  'bg_target_high': int(self.body[14]),
@@ -232,5 +232,3 @@ class CalBGForPH(KnownRecord):
 if __name__ == '__main__':
   import doctest
   doctest.testmod( )
-
-


### PR DESCRIPTION
See the Carelink csv below for verification of correct decoding.

pete$ ruby -Ilib bin/decode_history_page -d /Users/pete/dev/decoding-carelink/analysis/736868/logs/ReadHistoryData-page-0.data 523
record[0]:BolusWizard - :carb_ratio mismatch. decocare = 8.0, minimed_rf = 6.0
/Users/pete/dev/decoding-carelink/analysis/736868/logs/../CareLink-Export-1431237740531.csv:17221,3/28/15,21:29:36,3/28/15 21:29:36,,,,,,,,,,,,,,,0.0,120,90,6,40,0,0,0,0,0.0,,,,,,BolusWizardBolusEstimate,"BG_INPUT=0, BG_UNITS=mg dl, CARB_INPUT=0, CARB_UNITS=grams, CARB_RATIO=6, INSULIN_SENSITIVITY=40, BG_TARGET_LOW=90, BG_TARGET_HIGH=120, BOLUS_ESTIMATE=0, CORRECTION_ESTIMATE=0, FOOD_ESTIMATE=0, UNABSORBED_INSULIN_TOTAL=0, UNABSORBED_INSULIN_COUNT=15, ACTION_REQUESTOR=paradigm link or b key",14767324220,53801409,117,Paradigm Revel - 523
