### PR TITLE
Fix rounding errors in basal rate calculation

### DIFF
--- a/decocare/history.py
+++ b/decocare/history.py
@@ -105,7 +105,7 @@ class ChangeBasalProfile_old_profile (KnownRecord):
     return rates
 
 def describe_rate (offset, rate, q):
-  return (dict(offset=(30*1000*60)*offset, rate=rate*0.025))
+  return (dict(offset=(30*1000*60)*offset, rate=rate/40.0))
 
 
 class ChangeBasalProfile_new_profile (KnownRecord):


### PR DESCRIPTION
Dividing by 40 ends up with less fewer issues than multiplying by 0.025.

>>> 38 * 0.025
0.9500000000000001
>>> 38 / 40.0
0.95
