### PR TITLE
[mmeowlink_temp_basal] Handle empty byte arrays on temp basal response

### DIFF
--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -270,7 +270,7 @@ class TempBasal(PumpCommand):
 
   def getData(self):
     status = { 0: 'absolute' }
-    received = True if self.data[0] is 0 else False
+    received = True if (len(self.data) > 0 and self.data[0] is 0) else False
     return dict(recieved=received, temp=status.get(self.params[0], 'percent'))
   @classmethod
   def Program (klass, rate=None, duration=None, temp=None, **kwds):


### PR DESCRIPTION
In certain cases with mmeowlink, self.data is a blank bytearray as there is no
radio data returned. Attempting to access the 0th element raises 'IndexError:
bytearray index out of range' in this case.

This change adds a simple guard clause to avoid the exception. When the correct
data is actually set in the data array on the second attempt, the code works as
expected and the temporary basal report stores the correct data.