### PR TITLE
Raise an error on CRC mismatch, rather than fail an assertion

### DIFF
--- a/decocare/cgm/__init__.py
+++ b/decocare/cgm/__init__.py
@@ -18,6 +18,7 @@ from dateutil.relativedelta import relativedelta
 
 from decocare import lib
 from decocare.records import times
+from decocare.errors import DataTransferCorruptionError
 from pprint import pprint
 
 ###################
@@ -87,7 +88,7 @@ class PagedData (object):
     computed = lib.CRC16CCITT.compute(bytearray(data))
     self.larger = larger
     if lib.BangInt(crc) != computed:
-      assert lib.BangInt(crc) == computed, "CRC does not match page data"
+      raise DataTransferCorruptionError("CRC does not match page data")
     
     data.reverse( )
     self.data = self.eat_nulls(data)

--- a/decocare/errors.py
+++ b/decocare/errors.py
@@ -5,5 +5,7 @@ class AckError(StickError): pass
 
 class BadDeviceCommError(AckError): pass
 
+class DataTransferCorruptionError(Exception): pass
+
 #####
 # EOF


### PR DESCRIPTION
In some cases mmeowlink encounters CRC errors in data pages, even though the
comms channel CRCs are correct. This triggers a decocare assertion error.

I'm changing this to a 'raise' error instead, so that it can be caught by
openaps and retried.