### PR TITLE
avoid error from pyserial when opening port

### DIFF
--- a/decocare/link.py
+++ b/decocare/link.py
@@ -21,7 +21,7 @@ class Link( object ):
       self.__timeout__ = timeout
     if fuser.in_use(port):
       raise AlreadyInUseException("{port} already in use".format(port=port))
-    self.open( port )
+    self.open( port, dsrdtr=True, rtscts=True )
 
 
   def open( self, newPort=False, **kwds ):


### PR DESCRIPTION
Pass dsrdtr=True and rtscts=True to serial.Serial() to avoid the error described here:
    https://github.com/pyserial/pyserial/issues/59