### PR TITLE
Floating point accuracy fix in set_temp_basal

### DIFF
--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -293,7 +293,7 @@ class TempBasal(PumpCommand):
   @classmethod
   def format_params (klass, rate, duration):
     duration = duration / 30
-    rate = int(rate / 0.025)
+    rate = int(round(rate / 0.025))
     params = [0x00, rate, duration]
     return params
 


### PR DESCRIPTION
Basal rates weren't being set correctly in the pump (e.g. 0.6u/hr was being set as 0.575u/hr)

if rate = 0.6:

```
>>> int(0.6/0.025)
23
>>> 0.6/0.025
23.999999999999996
```

If the user is trying to set a basal rate that the pump can support, this should always result in better behaviour than the current code. oref0 dev should only try to set supported rates. 

If users try to set basal rates not supported by the pump, it could end up setting a rate up to 0.0125u/hr more than they requested.
